### PR TITLE
ArchivesSpace.add_digital_object fixes, add tests

### DIFF
--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -702,7 +702,7 @@ class ArchivesSpaceClient(object):
             new_object["notes"].append({
                 "jsonmodel_type": "note_digital_object",
                 "type": dnote,
-                "label": pnote["label"],
+                "label": pnote.get("label", ""),
                 "content": content,
                 "publish": pnote["publish"],
             })

--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -666,18 +666,19 @@ class ArchivesSpaceClient(object):
             "digital_object_id": identifier,
             "digital_object_type": object_type,
             "language": language,
+            "notes": [],
             "restrictions": restricted,
             "subjects": parent_record['subjects'],
             "linked_agents": parent_record['linked_agents'],
         }
 
         if location_of_originals is not None:
-            new_object["notes"] = [{
+            new_object["notes"].append({
                 "jsonmodel_type": "note_digital_object",
                 "type": "originalsloc",
                 "content": [location_of_originals],
                 "publish": True,
-            }]
+            })
 
         if uri is not None:
             new_object["file_versions"] = [{

--- a/tests/fixtures/test_add_digital_object.yaml
+++ b/tests/fixtures/test_add_digital_object.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: !!binary |
+      cGFzc3dvcmQ9YWRtaW4mZXhwaXJpbmc9RmFsc2U=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['29']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.8.1]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: '{"session":"2e06c62e8123488f45750959e77129fd7bf532fec10ffd0301568ffedee188de","user":{"lock_version":712,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2015-12-03T01:23:59Z","user_mtime":"2015-12-03T01:23:59Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2206']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:59 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2e06c62e8123488f45750959e77129fd7bf532fec10ffd0301568ffedee188de]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: '{"lock_version":9,"position":0,"publish":false,"ref_id":"e61c441cd04eb5731ce64de35a4339ff","component_id":"F1-1-1","title":"Test
+        edited subseries","display_string":"Test edited subseries, November, 2014
+        to November, 2015","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:19Z","system_mtime":"2015-12-03T01:23:47Z","user_mtime":"2015-12-03T01:23:47Z","suppressed":false,"level":"subseries","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[{"lock_version":0,"expression":"November,
+        2014 to November, 2015","begin":"2014-11-01","end":"2015-11-01","created_by":"admin","last_modified_by":"admin","create_time":"2015-12-03T01:23:47Z","system_mtime":"2015-12-03T01:23:47Z","user_mtime":"2015-12-03T01:23:47Z","date_type":"inclusive","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-03T01:23:47Z","system_mtime":"2015-12-03T01:23:47Z","user_mtime":"2015-12-03T01:23:47Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/7"}}],"notes":[{"subnotes":[{"publish":true,"jsonmodel_type":"note_text","content":"This
+        is a test note"}],"persistent_id":"063373886a2f23d03fe1a51f7c96ca8b","type":"odd","jsonmodel_type":"note_multipart","publish":true}],"uri":"/repositories/2/archival_objects/3","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['1703']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:59 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJsYW5ndWFnZSI6ICIiLCAibGlua2VkX2FnZW50cyI6IFtdLCAibm90ZXMiOiBbeyJsYWJlbCI6
+      ICIiLCAiY29udGVudCI6IFsiVGhpcyBpcyBhIHRlc3Qgbm90ZSJdLCAicHVibGlzaCI6IHRydWUs
+      ICJ0eXBlIjogIm5vdGUiLCAianNvbm1vZGVsX3R5cGUiOiAibm90ZV9kaWdpdGFsX29iamVjdCJ9
+      XSwgInRpdGxlIjogIlRlc3QgZGlnaXRhbCBvYmplY3QiLCAic3ViamVjdHMiOiBbXSwgInJlc3Ry
+      aWN0aW9ucyI6IGZhbHNlLCAiZGlnaXRhbF9vYmplY3RfdHlwZSI6ICJ0ZXh0IiwgImRpZ2l0YWxf
+      b2JqZWN0X2lkIjogIjM4Yzk5ZTg5LTIwYTEtNDgzMS1iYTU3LTgxM2ZiNjQyMGU1OSJ9
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['336']
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2e06c62e8123488f45750959e77129fd7bf532fec10ffd0301568ffedee188de]
+    method: POST
+    uri: http://localhost:8089/repositories/2/digital_objects
+  response:
+    body: {string: '{"status":"Created","id":8,"lock_version":0,"stale":null,"uri":"/repositories/2/digital_objects/8","warnings":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['114']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:59 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ1cmkiOiAiL3JlcG9zaXRvcmllcy8yL2FyY2hpdmFsX29iamVjdHMvMyIsICJyZXNvdXJjZSI6
+      IHsicmVmIjogIi9yZXBvc2l0b3JpZXMvMi9yZXNvdXJjZXMvMSJ9LCAibGV2ZWwiOiAic3Vic2Vy
+      aWVzIiwgInJpZ2h0c19zdGF0ZW1lbnRzIjogW10sICJ0aXRsZSI6ICJUZXN0IGVkaXRlZCBzdWJz
+      ZXJpZXMiLCAibGlua2VkX2V2ZW50cyI6IFtdLCAidXNlcl9tdGltZSI6ICIyMDE1LTEyLTAzVDAx
+      OjIzOjQ3WiIsICJyZXN0cmljdGlvbnNfYXBwbHkiOiBmYWxzZSwgInJlZl9pZCI6ICJlNjFjNDQx
+      Y2QwNGViNTczMWNlNjRkZTM1YTQzMzlmZiIsICJleHRlcm5hbF9pZHMiOiBbXSwgInN1YmplY3Rz
+      IjogW10sICJleHRlbnRzIjogW10sICJsaW5rZWRfYWdlbnRzIjogW10sICJjcmVhdGVkX2J5Ijog
+      ImFkbWluIiwgInN1cHByZXNzZWQiOiBmYWxzZSwgImNvbXBvbmVudF9pZCI6ICJGMS0xLTEiLCAi
+      ZGlzcGxheV9zdHJpbmciOiAiVGVzdCBlZGl0ZWQgc3Vic2VyaWVzLCBOb3ZlbWJlciwgMjAxNCB0
+      byBOb3ZlbWJlciwgMjAxNSIsICJsYXN0X21vZGlmaWVkX2J5IjogImFkbWluIiwgInBhcmVudCI6
+      IHsicmVmIjogIi9yZXBvc2l0b3JpZXMvMi9hcmNoaXZhbF9vYmplY3RzLzEifSwgInJlcG9zaXRv
+      cnkiOiB7InJlZiI6ICIvcmVwb3NpdG9yaWVzLzIifSwgIm5vdGVzIjogW3sianNvbm1vZGVsX3R5
+      cGUiOiAibm90ZV9tdWx0aXBhcnQiLCAicHVibGlzaCI6IHRydWUsICJwZXJzaXN0ZW50X2lkIjog
+      IjA2MzM3Mzg4NmEyZjIzZDAzZmUxYTUxZjdjOTZjYThiIiwgInN1Ym5vdGVzIjogW3siY29udGVu
+      dCI6ICJUaGlzIGlzIGEgdGVzdCBub3RlIiwgInB1Ymxpc2giOiB0cnVlLCAianNvbm1vZGVsX3R5
+      cGUiOiAibm90ZV90ZXh0In1dLCAidHlwZSI6ICJvZGQifV0sICJqc29ubW9kZWxfdHlwZSI6ICJh
+      cmNoaXZhbF9vYmplY3QiLCAicHVibGlzaCI6IGZhbHNlLCAic3lzdGVtX210aW1lIjogIjIwMTUt
+      MTItMDNUMDE6MjM6NDdaIiwgImNyZWF0ZV90aW1lIjogIjIwMTUtMDYtMTFUMTc6MjA6MTlaIiwg
+      InBvc2l0aW9uIjogMCwgImxvY2tfdmVyc2lvbiI6IDksICJpbnN0YW5jZXMiOiBbeyJjcmVhdGVf
+      dGltZSI6ICIyMDE1LTEyLTAzVDAxOjIzOjQ3WiIsICJqc29ubW9kZWxfdHlwZSI6ICJpbnN0YW5j
+      ZSIsICJsb2NrX3ZlcnNpb24iOiAwLCAiY3JlYXRlZF9ieSI6ICJhZG1pbiIsICJkaWdpdGFsX29i
+      amVjdCI6IHsicmVmIjogIi9yZXBvc2l0b3JpZXMvMi9kaWdpdGFsX29iamVjdHMvNyJ9LCAidXNl
+      cl9tdGltZSI6ICIyMDE1LTEyLTAzVDAxOjIzOjQ3WiIsICJzeXN0ZW1fbXRpbWUiOiAiMjAxNS0x
+      Mi0wM1QwMToyMzo0N1oiLCAiaW5zdGFuY2VfdHlwZSI6ICJkaWdpdGFsX29iamVjdCIsICJsYXN0
+      X21vZGlmaWVkX2J5IjogImFkbWluIn0sIHsiZGlnaXRhbF9vYmplY3QiOiB7InJlZiI6ICIvcmVw
+      b3NpdG9yaWVzLzIvZGlnaXRhbF9vYmplY3RzLzgifSwgImluc3RhbmNlX3R5cGUiOiAiZGlnaXRh
+      bF9vYmplY3QifV0sICJkYXRlcyI6IFt7ImJlZ2luIjogIjIwMTQtMTEtMDEiLCAiZXhwcmVzc2lv
+      biI6ICJOb3ZlbWJlciwgMjAxNCB0byBOb3ZlbWJlciwgMjAxNSIsICJqc29ubW9kZWxfdHlwZSI6
+      ICJkYXRlIiwgImxhYmVsIjogImNyZWF0aW9uIiwgInN5c3RlbV9tdGltZSI6ICIyMDE1LTEyLTAz
+      VDAxOjIzOjQ3WiIsICJ1c2VyX210aW1lIjogIjIwMTUtMTItMDNUMDE6MjM6NDdaIiwgImRhdGVf
+      dHlwZSI6ICJpbmNsdXNpdmUiLCAiY3JlYXRlX3RpbWUiOiAiMjAxNS0xMi0wM1QwMToyMzo0N1oi
+      LCAibG9ja192ZXJzaW9uIjogMCwgImNyZWF0ZWRfYnkiOiAiYWRtaW4iLCAiZW5kIjogIjIwMTUt
+      MTEtMDEiLCAibGFzdF9tb2RpZmllZF9ieSI6ICJhZG1pbiJ9XSwgImhhc191bnB1Ymxpc2hlZF9h
+      bmNlc3RvciI6IHRydWUsICJleHRlcm5hbF9kb2N1bWVudHMiOiBbXX0=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1922']
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2e06c62e8123488f45750959e77129fd7bf532fec10ffd0301568ffedee188de]
+    method: POST
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: '{"status":"Updated","id":3,"lock_version":10,"stale":true,"uri":"/repositories/2/archival_objects/3","warnings":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:24:00 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/test_add_digital_object_note.yaml
+++ b/tests/fixtures/test_add_digital_object_note.yaml
@@ -1,0 +1,160 @@
+interactions:
+- request:
+    body: !!binary |
+      cGFzc3dvcmQ9YWRtaW4mZXhwaXJpbmc9RmFsc2U=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['29']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.8.1]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: '{"session":"d6226a61876a4e58aff36f9a4d549330abe76909660b1f3de4f50f11db6750c0","user":{"lock_version":711,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2015-12-03T01:23:46Z","user_mtime":"2015-12-03T01:23:46Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2206']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:46 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [d6226a61876a4e58aff36f9a4d549330abe76909660b1f3de4f50f11db6750c0]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: '{"lock_version":8,"position":0,"publish":false,"ref_id":"e61c441cd04eb5731ce64de35a4339ff","component_id":"F1-1-1","title":"Test
+        edited subseries","display_string":"Test edited subseries, November, 2014
+        to November, 2015","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:19Z","system_mtime":"2015-12-03T00:03:42Z","user_mtime":"2015-11-02T22:53:07Z","suppressed":false,"level":"subseries","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[{"lock_version":0,"expression":"November,
+        2014 to November, 2015","begin":"2014-11-01","end":"2015-11-01","created_by":"admin","last_modified_by":"admin","create_time":"2015-11-02T22:53:07Z","system_mtime":"2015-11-02T22:53:07Z","user_mtime":"2015-11-02T22:53:07Z","date_type":"inclusive","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[{"type":"odd","jsonmodel_type":"note_multipart","subnotes":[{"content":"This
+        is a test note","publish":true,"jsonmodel_type":"note_text"}],"persistent_id":"063373886a2f23d03fe1a51f7c96ca8b","publish":true}],"uri":"/repositories/2/archival_objects/3","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['1404']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:46 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJkaWdpdGFsX29iamVjdF9pZCI6ICI5MjViZmM4YS1kNmY4LTQ0NzktOWI2YS1kODExYTRlN2Y2
+      YmYiLCAibGFuZ3VhZ2UiOiAiIiwgImxpbmtlZF9hZ2VudHMiOiBbXSwgInRpdGxlIjogIlRlc3Qg
+      ZGlnaXRhbCBvYmplY3Qgd2l0aCBub3RlIiwgImRpZ2l0YWxfb2JqZWN0X3R5cGUiOiAidGV4dCIs
+      ICJub3RlcyI6IFt7InB1Ymxpc2giOiB0cnVlLCAidHlwZSI6ICJvcmlnaW5hbHNsb2MiLCAianNv
+      bm1vZGVsX3R5cGUiOiAibm90ZV9kaWdpdGFsX29iamVjdCIsICJjb250ZW50IjogWyJUaGUgZXRo
+      ZXIiXX0sIHsicHVibGlzaCI6IHRydWUsICJ0eXBlIjogIm5vdGUiLCAianNvbm1vZGVsX3R5cGUi
+      OiAibm90ZV9kaWdpdGFsX29iamVjdCIsICJjb250ZW50IjogWyJUaGlzIGlzIGEgdGVzdCBub3Rl
+      Il0sICJsYWJlbCI6ICIifV0sICJyZXN0cmljdGlvbnMiOiBmYWxzZSwgInN1YmplY3RzIjogW119
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['456']
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [d6226a61876a4e58aff36f9a4d549330abe76909660b1f3de4f50f11db6750c0]
+    method: POST
+    uri: http://localhost:8089/repositories/2/digital_objects
+  response:
+    body: {string: '{"status":"Created","id":7,"lock_version":0,"stale":null,"uri":"/repositories/2/digital_objects/7","warnings":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['114']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:46 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJyZXBvc2l0b3J5IjogeyJyZWYiOiAiL3JlcG9zaXRvcmllcy8yIn0sICJleHRlcm5hbF9kb2N1
+      bWVudHMiOiBbXSwgImRhdGVzIjogW3sibGFiZWwiOiAiY3JlYXRpb24iLCAiZW5kIjogIjIwMTUt
+      MTEtMDEiLCAic3lzdGVtX210aW1lIjogIjIwMTUtMTEtMDJUMjI6NTM6MDdaIiwgImNyZWF0ZV90
+      aW1lIjogIjIwMTUtMTEtMDJUMjI6NTM6MDdaIiwgImxvY2tfdmVyc2lvbiI6IDAsICJkYXRlX3R5
+      cGUiOiAiaW5jbHVzaXZlIiwgImV4cHJlc3Npb24iOiAiTm92ZW1iZXIsIDIwMTQgdG8gTm92ZW1i
+      ZXIsIDIwMTUiLCAiYmVnaW4iOiAiMjAxNC0xMS0wMSIsICJqc29ubW9kZWxfdHlwZSI6ICJkYXRl
+      IiwgImNyZWF0ZWRfYnkiOiAiYWRtaW4iLCAibGFzdF9tb2RpZmllZF9ieSI6ICJhZG1pbiIsICJ1
+      c2VyX210aW1lIjogIjIwMTUtMTEtMDJUMjI6NTM6MDdaIn1dLCAiY29tcG9uZW50X2lkIjogIkYx
+      LTEtMSIsICJwYXJlbnQiOiB7InJlZiI6ICIvcmVwb3NpdG9yaWVzLzIvYXJjaGl2YWxfb2JqZWN0
+      cy8xIn0sICJ1cmkiOiAiL3JlcG9zaXRvcmllcy8yL2FyY2hpdmFsX29iamVjdHMvMyIsICJzdXBw
+      cmVzc2VkIjogZmFsc2UsICJleHRlbnRzIjogW10sICJub3RlcyI6IFt7InN1Ym5vdGVzIjogW3si
+      cHVibGlzaCI6IHRydWUsICJqc29ubW9kZWxfdHlwZSI6ICJub3RlX3RleHQiLCAiY29udGVudCI6
+      ICJUaGlzIGlzIGEgdGVzdCBub3RlIn1dLCAicHVibGlzaCI6IHRydWUsICJwZXJzaXN0ZW50X2lk
+      IjogIjA2MzM3Mzg4NmEyZjIzZDAzZmUxYTUxZjdjOTZjYThiIiwgInR5cGUiOiAib2RkIiwgImpz
+      b25tb2RlbF90eXBlIjogIm5vdGVfbXVsdGlwYXJ0In1dLCAibGV2ZWwiOiAic3Vic2VyaWVzIiwg
+      InVzZXJfbXRpbWUiOiAiMjAxNS0xMS0wMlQyMjo1MzowN1oiLCAiaW5zdGFuY2VzIjogW3siZGln
+      aXRhbF9vYmplY3QiOiB7InJlZiI6ICIvcmVwb3NpdG9yaWVzLzIvZGlnaXRhbF9vYmplY3RzLzci
+      fSwgImluc3RhbmNlX3R5cGUiOiAiZGlnaXRhbF9vYmplY3QifV0sICJyaWdodHNfc3RhdGVtZW50
+      cyI6IFtdLCAianNvbm1vZGVsX3R5cGUiOiAiYXJjaGl2YWxfb2JqZWN0IiwgImxpbmtlZF9hZ2Vu
+      dHMiOiBbXSwgInBvc2l0aW9uIjogMCwgInN5c3RlbV9tdGltZSI6ICIyMDE1LTEyLTAzVDAwOjAz
+      OjQyWiIsICJyZXNvdXJjZSI6IHsicmVmIjogIi9yZXBvc2l0b3JpZXMvMi9yZXNvdXJjZXMvMSJ9
+      LCAiY3JlYXRlX3RpbWUiOiAiMjAxNS0wNi0xMVQxNzoyMDoxOVoiLCAibG9ja192ZXJzaW9uIjog
+      OCwgInJlc3RyaWN0aW9uc19hcHBseSI6IGZhbHNlLCAiZXh0ZXJuYWxfaWRzIjogW10sICJkaXNw
+      bGF5X3N0cmluZyI6ICJUZXN0IGVkaXRlZCBzdWJzZXJpZXMsIE5vdmVtYmVyLCAyMDE0IHRvIE5v
+      dmVtYmVyLCAyMDE1IiwgInB1Ymxpc2giOiBmYWxzZSwgInRpdGxlIjogIlRlc3QgZWRpdGVkIHN1
+      YnNlcmllcyIsICJoYXNfdW5wdWJsaXNoZWRfYW5jZXN0b3IiOiB0cnVlLCAicmVmX2lkIjogImU2
+      MWM0NDFjZDA0ZWI1NzMxY2U2NGRlMzVhNDMzOWZmIiwgImxpbmtlZF9ldmVudHMiOiBbXSwgInN1
+      YmplY3RzIjogW10sICJjcmVhdGVkX2J5IjogImFkbWluIiwgImxhc3RfbW9kaWZpZWRfYnkiOiAi
+      YWRtaW4ifQ==
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1603']
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [d6226a61876a4e58aff36f9a4d549330abe76909660b1f3de4f50f11db6750c0]
+    method: POST
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: '{"status":"Updated","id":3,"lock_version":9,"stale":true,"uri":"/repositories/2/archival_objects/3","warnings":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['115']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:47 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [d6226a61876a4e58aff36f9a4d549330abe76909660b1f3de4f50f11db6750c0]
+    method: GET
+    uri: http://localhost:8089/repositories/2/digital_objects/7
+  response:
+    body: {string: '{"lock_version":1,"digital_object_id":"925bfc8a-d6f8-4479-9b6a-d811a4e7f6bf","title":"Test
+        digital object with note","restrictions":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-03T01:23:47Z","system_mtime":"2015-12-03T01:23:47Z","user_mtime":"2015-12-03T01:23:47Z","suppressed":false,"digital_object_type":"text","jsonmodel_type":"digital_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[],"external_documents":[],"rights_statements":[],"linked_agents":[],"file_versions":[],"notes":[{"type":"originalsloc","jsonmodel_type":"note_digital_object","content":["The
+        ether"],"persistent_id":"1b5d0feafe3c9d07fa515eb1e532c84c","publish":true},{"type":"note","jsonmodel_type":"note_digital_object","content":["This
+        is a test note"],"persistent_id":"27c98cdc882d66ee0177579bc89821ea","publish":true}],"linked_instances":[{"ref":"/repositories/2/archival_objects/3"}],"uri":"/repositories/2/digital_objects/7","repository":{"ref":"/repositories/2"},"tree":{"ref":"/repositories/2/digital_objects/7/tree"}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['1061']
+      Content-Type: [application/json]
+      Date: ['Thu, 03 Dec 2015 01:23:47 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_archivesspace_client.py
+++ b/tests/test_archivesspace_client.py
@@ -239,6 +239,27 @@ def test_edit_archival_object():
     assert updated['notes'][0]['subnotes'][0]['content'] == new_record['notes'][0]['content']
 
 
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_digital_object.yaml'))
+def test_add_digital_object():
+    client = ArchivesSpaceClient(**AUTH)
+    do = client.add_digital_object('/repositories/2/archival_objects/3',
+                                   identifier='38c99e89-20a1-4831-ba57-813fb6420e59',
+                                   title='Test digital object')
+    assert do['id'] == '/repositories/2/digital_objects/8'
+
+
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_digital_object_note.yaml'))
+def test_digital_object_with_location_of_originals_note():
+    client = ArchivesSpaceClient(**AUTH)
+    do = client.add_digital_object('/repositories/2/archival_objects/3',
+                                   identifier='925bfc8a-d6f8-4479-9b6a-d811a4e7f6bf',
+                                   title='Test digital object with note',
+                                   location_of_originals='The ether')
+    note = client.get_record(do['id'])['notes'][0]
+    assert note['content'][0] == 'The ether'
+    assert note['type'] == 'originalsloc'
+
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_digital_object_component.yaml'))
 def test_add_digital_object_component():
     client = ArchivesSpaceClient(**AUTH)


### PR DESCRIPTION
* Fixes an issue adding digital objects without a note specified if the parent object has notes
* Fixes an issue copying notes from the parent object if the parent object's notes do not have a label specified
* Adds tests for adding digital objects, including tests which catch the above errors