### PR TITLE
ArchivistsToolkitClient: use pymysql instead of MySQLdb

### DIFF
--- a/agentarchives/archivists_toolkit/client.py
+++ b/agentarchives/archivists_toolkit/client.py
@@ -1,6 +1,6 @@
 import logging
 
-import MySQLdb
+import pymysql as MySQLdb
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 requests>=2,<3
-MySQL-python>=1.2,<2
+pymysql>=0.6,<1


### PR DESCRIPTION
A brief test suggests this works fine, and works in Python 3.