### PR TITLE
ArchivesSpaceClient: include new display_title attribute, return titles properly

### DIFF
--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -318,6 +318,8 @@ class ArchivesSpaceClient(object):
                 'levelOfDescription': record['level'],
                 'notes': self._format_notes(full_record),
             }
+            if full_record.get('display_string') is not None:
+                result['display_title'] = full_record['display_string']
             if record['children'] and descend:
                 result['children'] = [format_record(child, level) for child in record['children']]
                 result['has_children'] = True
@@ -350,6 +352,7 @@ class ArchivesSpaceClient(object):
                 'sortPosition': level,
                 'identifier': record.get('component_id', ''),
                 'title': record.get('title', ''),
+                'display_title': record.get('display_string', ''),
                 'dates': dates,
                 'levelOfDescription': record['level'],
                 'notes': self._format_notes(record),

--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -313,7 +313,7 @@ class ArchivesSpaceClient(object):
                 'type': 'resource',
                 'sortPosition': level,
                 'identifier': identifier,
-                'title': record.get('title', ''),
+                'title': full_record.get('title', ''),
                 'dates': dates,
                 'levelOfDescription': record['level'],
                 'notes': self._format_notes(full_record),


### PR DESCRIPTION
The new display_title attribute contains a title formatted by the access system, which may concatenate several fields in the record. This is the field used by ArchivesSpace itself to render its UI. The source `display_string` field is only provided for resource components, not resources.

Also fixes a preexisting bug where `display_string` was returned as the `title` in certain circumstances.