### PR TITLE
Clients: return date_expression in records

### DIFF
--- a/agentarchives/archivists_toolkit/client.py
+++ b/agentarchives/archivists_toolkit/client.py
@@ -161,6 +161,7 @@ class ArchivistsToolkitClient(object):
           'title': 'Parent',
           'levelOfDescription': 'collection',
           'dates': '1880-1889',
+          'date_expression': '1880 to 1889',
           'notes': [
             'type': 'odd',
             'content': 'This is a note',
@@ -173,6 +174,7 @@ class ArchivistsToolkitClient(object):
             'title': 'Child A',
             'levelOfDescription': 'Sousfonds',
             'dates': '1880-1888',
+            'date_expression': '1880 to 1888',
             'notes': [],
             'children': [{
               'id': '24',
@@ -182,6 +184,7 @@ class ArchivistsToolkitClient(object):
               'title': 'Grandchild A',
               'levelOfDescription': 'Item',
               'dates': '1880-1888',
+              'date_expression': '1880 to 1888',
               'notes': [],
               'children': False
             },
@@ -204,6 +207,7 @@ class ArchivistsToolkitClient(object):
             'title': 'Child B',
             'levelOfDescription': 'Sousfonds',
             'dates': '1889',
+            'date_expression': '1889',
             'notes': [],
             'children': False
           }]
@@ -234,7 +238,9 @@ class ArchivistsToolkitClient(object):
                 resource_data['type']               = 'resource'
                 resource_data['sortPosition']       = sort_data['position']
                 resource_data['title']              = row[0]
+                # TODO reformat dates from the separate date fields, like ArchivesSpaceClient?
                 resource_data['dates']              = row[1]
+                resource_data['date_expression']    = row[1]
                 resource_data['identifier']         = row[2]
                 resource_data['levelOfDescription'] = row[3]
         else:
@@ -246,6 +252,7 @@ class ArchivistsToolkitClient(object):
                 resource_data['sortPosition']       = sort_data['position']
                 resource_data['title']              = row[0]
                 resource_data['dates']              = row[1]
+                resource_data['date_expression']    = row[1]
                 resource_data['identifier']         = row[2]
                 resource_data['levelOfDescription'] = row[3]
 

--- a/tests/fixtures/test_date_expression.yaml
+++ b/tests/fixtures/test_date_expression.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: !!binary |
+      ZXhwaXJpbmc9RmFsc2UmcGFzc3dvcmQ9YWRtaW4=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['29']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.8.1]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: '{"session":"d81a358cd432e897d69df8d17afe43dc0b70f1bc6db988f1dc291becbc510663","user":{"lock_version":780,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2015-12-04T22:56:50Z","user_mtime":"2015-12-04T22:56:50Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2206']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 22:56:50 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [d81a358cd432e897d69df8d17afe43dc0b70f1bc6db988f1dc291becbc510663]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: '{"lock_version":10,"position":0,"publish":false,"ref_id":"e61c441cd04eb5731ce64de35a4339ff","component_id":"F1-1-1","title":"Test
+        edited subseries","display_string":"Test edited subseries, November, 2014
+        to November, 2015","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:19Z","system_mtime":"2015-12-04T00:59:36Z","user_mtime":"2015-12-03T01:24:00Z","suppressed":false,"level":"subseries","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[{"lock_version":0,"expression":"November,
+        2014 to November, 2015","begin":"2014-11-01","end":"2015-11-01","created_by":"admin","last_modified_by":"admin","create_time":"2015-12-03T01:24:00Z","system_mtime":"2015-12-03T01:24:00Z","user_mtime":"2015-12-03T01:24:00Z","date_type":"inclusive","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-03T01:24:00Z","system_mtime":"2015-12-03T01:24:00Z","user_mtime":"2015-12-03T01:24:00Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/7"}},{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-03T01:24:00Z","system_mtime":"2015-12-03T01:24:00Z","user_mtime":"2015-12-03T01:24:00Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/8"}}],"notes":[{"jsonmodel_type":"note_multipart","persistent_id":"063373886a2f23d03fe1a51f7c96ca8b","subnotes":[{"content":"This
+        is a test note","publish":true,"jsonmodel_type":"note_text"}],"type":"odd","publish":true}],"uri":"/repositories/2/archival_objects/3","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2004']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 22:56:50 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [d81a358cd432e897d69df8d17afe43dc0b70f1bc6db988f1dc291becbc510663]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3/children
+  response:
+    body: {string: '[{"lock_version":1,"position":0,"publish":false,"ref_id":"8429037b0f599a1efcca06b9b813700a","component_id":"F1-1-1-1","title":"Test
+        file","display_string":"Test file","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:30Z","system_mtime":"2015-12-04T00:59:36Z","user_mtime":"2015-06-11T17:45:40Z","suppressed":false,"level":"file","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[],"uri":"/repositories/2/archival_objects/4","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/3"},"has_unpublished_ancestor":true}]
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['808']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 22:56:50 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/test_empty_dates.yaml
+++ b/tests/fixtures/test_empty_dates.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: !!binary |
+      cGFzc3dvcmQ9YWRtaW4mZXhwaXJpbmc9RmFsc2U=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['29']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.8.1]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: '{"session":"2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5","user":{"lock_version":784,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2015-12-04T23:26:24Z","user_mtime":"2015-12-04T23:26:24Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2206']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/2
+  response:
+    body: {string: '{"lock_version":1,"position":1,"publish":false,"ref_id":"2d6194e7945563b58be69b5a70887239","component_id":"F1-2","title":"Test
+        series 2","display_string":"Test series 2","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:15:03Z","system_mtime":"2015-12-03T00:03:42Z","user_mtime":"2015-06-11T17:46:12Z","suppressed":false,"level":"series","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[],"uri":"/repositories/2/archival_objects/2","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['758']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/2/children
+  response:
+    body: {string: '[{"lock_version":0,"position":0,"ref_id":"f9db798809e30de21950f0414f09fb76","title":"Test
+        bad resource","display_string":"Test bad resource","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-09-10T18:21:17Z","system_mtime":"2015-12-02T01:05:22Z","user_mtime":"2015-09-10T18:21:17Z","suppressed":false,"level":"series","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[],"uri":"/repositories/2/archival_objects/7","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/2"},"parent":{"ref":"/repositories/2/archival_objects/2"},"has_unpublished_ancestor":true}]
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['784']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/7/children
+  response:
+    body: {string: '[]
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['3']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/2/tree
+  response:
+    body: {string: '{"title":"Some other fonds","id":2,"node_type":"resource","publish":false,"suppressed":false,"children":[{"title":"New
+        resource child","id":12,"record_uri":"/repositories/2/archival_objects/12","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]}],"record_uri":"/repositories/2/resources/2","level":"fonds","jsonmodel_type":"resource_tree","instance_types":[],"containers":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['478']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/2
+  response:
+    body: {string: '{"lock_version":4,"title":"Some other fonds","publish":false,"restrictions":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-30T23:17:57Z","system_mtime":"2015-12-02T01:05:21Z","user_mtime":"2015-12-02T01:05:21Z","suppressed":false,"id_0":"F2","level":"fonds","jsonmodel_type":"resource","external_ids":[],"subjects":[],"linked_events":[],"extents":[{"lock_version":0,"number":"1","created_by":"admin","last_modified_by":"admin","create_time":"2015-12-02T01:05:21Z","system_mtime":"2015-12-02T01:05:21Z","user_mtime":"2015-12-02T01:05:21Z","portion":"whole","extent_type":"cassettes","jsonmodel_type":"extent"}],"dates":[{"lock_version":0,"begin":"2015-06-29","created_by":"admin","last_modified_by":"admin","create_time":"2015-12-02T01:05:21Z","system_mtime":"2015-12-02T01:05:21Z","user_mtime":"2015-12-02T01:05:21Z","date_type":"bulk","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-02T01:05:21Z","system_mtime":"2015-12-02T01:05:21Z","user_mtime":"2015-12-02T01:05:21Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/3"}},{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-02T01:05:22Z","system_mtime":"2015-12-02T01:05:22Z","user_mtime":"2015-12-02T01:05:22Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/4"}},{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-02T01:05:22Z","system_mtime":"2015-12-02T01:05:22Z","user_mtime":"2015-12-02T01:05:22Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/5"}},{"lock_version":0,"created_by":"admin","last_modified_by":"admin","create_time":"2015-12-02T01:05:22Z","system_mtime":"2015-12-02T01:05:22Z","user_mtime":"2015-12-02T01:05:22Z","instance_type":"digital_object","jsonmodel_type":"instance","digital_object":{"ref":"/repositories/2/digital_objects/6"}}],"deaccessions":[],"related_accessions":[],"notes":[],"uri":"/repositories/2/resources/2","repository":{"ref":"/repositories/2"},"tree":{"ref":"/repositories/2/resources/2/tree"}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2370']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/search?page_size=30&page=1&q=primary_type%3Aresource
+  response:
+    body: {string: '{"first_page":1,"last_page":1,"this_page":1,"offset_first":1,"offset_last":2,"total_hits":2,"results":[{"id":"/repositories/2/resources/1","title":"Test
+        fonds","primary_type":"resource","types":["resource"],"json":"{\"lock_version\":11,\"title\":\"Test
+        fonds\",\"publish\":false,\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-06-11T17:08:42Z\",\"system_mtime\":\"2015-12-03T00:03:41Z\",\"user_mtime\":\"2015-12-03T00:03:41Z\",\"suppressed\":false,\"id_0\":\"F1\",\"language\":\"eng\",\"level\":\"fonds\",\"jsonmodel_type\":\"resource\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[{\"lock_version\":0,\"number\":\"1\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-03T00:03:42Z\",\"system_mtime\":\"2015-12-03T00:03:42Z\",\"user_mtime\":\"2015-12-03T00:03:42Z\",\"portion\":\"whole\",\"extent_type\":\"cassettes\",\"jsonmodel_type\":\"extent\"}],\"dates\":[{\"lock_version\":0,\"begin\":\"2015-01-01\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-03T00:03:42Z\",\"system_mtime\":\"2015-12-03T00:03:42Z\",\"user_mtime\":\"2015-12-03T00:03:42Z\",\"date_type\":\"single\",\"label\":\"creation\",\"jsonmodel_type\":\"date\"}],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"instances\":[],\"deaccessions\":[],\"related_accessions\":[{\"ref\":\"/repositories/2/accessions/1\"}],\"notes\":[{\"content\":[\"Singlepart
+        note\"],\"type\":\"physdesc\",\"jsonmodel_type\":\"note_singlepart\",\"persistent_id\":\"cdc013c483de98b8a1762302faf8fd32\",\"publish\":true}],\"uri\":\"/repositories/2/resources/1\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/resources/1/tree\"}}","suppressed":false,"publish":false,"system_generated":false,"repository":"/repositories/2","created_by":"admin","last_modified_by":"admin","user_mtime":"2015-12-03T00:03:41Z","system_mtime":"2015-12-03T00:03:41Z","create_time":"2015-06-11T17:08:42Z","level":"fonds","identifier":"F1","language":"eng","restrictions":"false","four_part_id":"F1","uri":"/repositories/2/resources/1","jsonmodel_type":"resource"},{"id":"/repositories/2/resources/2","title":"Some
+        other fonds","primary_type":"resource","types":["resource"],"json":"{\"lock_version\":4,\"title\":\"Some
+        other fonds\",\"publish\":false,\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-06-30T23:17:57Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"suppressed\":false,\"id_0\":\"F2\",\"level\":\"fonds\",\"jsonmodel_type\":\"resource\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[{\"lock_version\":0,\"number\":\"1\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"portion\":\"whole\",\"extent_type\":\"cassettes\",\"jsonmodel_type\":\"extent\"}],\"dates\":[{\"lock_version\":0,\"begin\":\"2015-06-29\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"date_type\":\"bulk\",\"label\":\"creation\",\"jsonmodel_type\":\"date\"}],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"instances\":[{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/3\",\"_resolved\":{\"lock_version\":4,\"digital_object_id\":\"f808032e-c6ec-4242-b7aa-5395988b9f7e\",\"title\":\"test\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T00:55:38Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T00:55:38Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"4e5eec95fcb62440f20a4f5b89c6d16b\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/3\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/3/tree\"}}}},{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:22Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:22Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/4\",\"_resolved\":{\"lock_version\":3,\"digital_object_id\":\"5517ddb1-36dd-4a02-a363-f1571982670f\",\"title\":\"test\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T00:55:53Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T00:55:53Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"bdfe911944a3d26a9fd43455aa968c52\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/4\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/4/tree\"}}}},{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:22Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:22Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/5\",\"_resolved\":{\"lock_version\":2,\"digital_object_id\":\"8ea81c4d-6df3-4775-a314-4bef4f44dd3c\",\"title\":\"Some
+        other fonds\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:04:57Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:04:57Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"68242ba5c0cbff4b674c6a2fa2335ad0\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/5\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/5/tree\"}}}},{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:22Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:22Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/6\",\"_resolved\":{\"lock_version\":1,\"digital_object_id\":\"a1672927-9a56-41c4-b423-5d76e4a1c660\",\"title\":\"Some
+        other fonds\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"3453d8096aabc607723b4359ab8fdd3c\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/6\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/6/tree\"}}}}],\"deaccessions\":[],\"related_accessions\":[],\"notes\":[],\"uri\":\"/repositories/2/resources/2\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/resources/2/tree\"}}","suppressed":false,"publish":false,"system_generated":false,"repository":"/repositories/2","created_by":"admin","last_modified_by":"admin","user_mtime":"2015-12-02T01:05:21Z","system_mtime":"2015-12-02T01:05:21Z","create_time":"2015-06-30T23:17:57Z","level":"fonds","identifier":"F2","restrictions":"false","four_part_id":"F2","uri":"/repositories/2/resources/2","jsonmodel_type":"resource"}],"facets":{"facet_queries":{},"facet_fields":{},"facet_dates":{},"facet_ranges":{}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['9418']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:24 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/1/tree?page=1
+  response:
+    body: {string: '{"title":"Test fonds","id":1,"node_type":"resource","publish":false,"suppressed":false,"children":[{"title":"Test
+        series, 1950 - 1972","id":1,"record_uri":"/repositories/2/archival_objects/1","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":true,"children":[{"title":"Test
+        edited subseries, November, 2014 to November, 2015","id":3,"record_uri":"/repositories/2/archival_objects/3","publish":false,"suppressed":false,"node_type":"archival_object","level":"subseries","has_children":true,"children":[{"title":"Test
+        file","id":4,"record_uri":"/repositories/2/archival_objects/4","publish":false,"suppressed":false,"node_type":"archival_object","level":"file","has_children":false,"children":[],"instance_types":[],"containers":[]}],"instance_types":[],"containers":[]},{"title":"New
+        new new child","id":10,"record_uri":"/repositories/2/archival_objects/10","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]}],"instance_types":[],"containers":[]},{"title":"Test
+        series 2","id":2,"record_uri":"/repositories/2/archival_objects/2","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Test
+        new child","id":13,"record_uri":"/repositories/2/archival_objects/13","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Test
+        new child 2","id":14,"record_uri":"/repositories/2/archival_objects/14","publish":false,"suppressed":false,"node_type":"archival_object","level":"item","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Test
+        new child 3","id":16,"record_uri":"/repositories/2/archival_objects/16","publish":false,"suppressed":false,"node_type":"archival_object","level":"class","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"New
+        child with note","id":17,"record_uri":"/repositories/2/archival_objects/17","publish":false,"suppressed":false,"node_type":"archival_object","level":"class","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"New
+        child final","id":18,"record_uri":"/repositories/2/archival_objects/18","publish":false,"suppressed":false,"node_type":"archival_object","level":null,"has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Child
+        with no note","id":19,"record_uri":"/repositories/2/archival_objects/19","publish":false,"suppressed":false,"node_type":"archival_object","level":"fonds","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Child
+        with no note","id":20,"record_uri":"/repositories/2/archival_objects/20","publish":false,"suppressed":false,"node_type":"archival_object","level":"fonds","has_children":false,"children":[],"instance_types":[],"containers":[]}],"record_uri":"/repositories/2/resources/1","level":"fonds","jsonmodel_type":"resource_tree","instance_types":[],"containers":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['3142']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:25 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.8.1]
+      X-ArchivesSpace-Session: [2661a9a15d0a2667572979a5d5d88678fc79554aa9cca99b48111c2da65508a5]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/2/tree?page=1
+  response:
+    body: {string: '{"title":"Some other fonds","id":2,"node_type":"resource","publish":false,"suppressed":false,"children":[{"title":"New
+        resource child","id":12,"record_uri":"/repositories/2/archival_objects/12","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]}],"record_uri":"/repositories/2/resources/2","level":"fonds","jsonmodel_type":"resource_tree","instance_types":[],"containers":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['478']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Dec 2015 23:26:25 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_archivesspace_client.py
+++ b/tests/test_archivesspace_client.py
@@ -280,3 +280,25 @@ def test_add_nested_digital_object_component():
                                               label='Child DOC',
                                               title='This is a child DOC')
     assert client.get_record(doc['id'])['parent']['ref'] == parent
+
+
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_date_expression.yaml'))
+def test_date_expression():
+    client = ArchivesSpaceClient(**AUTH)
+    record = client.get_resource_component_and_children('/repositories/2/archival_objects/3',
+                                                        recurse_max_level=1)
+    assert record['date_expression'] == 'November, 2014 to November, 2015'
+
+
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_empty_dates.yaml'))
+def test_empty_dates():
+    client = ArchivesSpaceClient(**AUTH)
+    record = client.get_resource_component_children('/repositories/2/archival_objects/2')
+    assert record['dates'] == ''
+    assert record['date_expression'] == ''
+    record = client.get_resource_component_and_children('/repositories/2/resources/2',
+                                                        recurse_max_level=1)
+    # dates are mandatory for resources, so this record does have a date but no expression
+    assert record['date_expression'] == ''
+    collections = client.find_collections()
+    assert collections[0]['date_expression'] == ''


### PR DESCRIPTION
For ArchivesSpaceClient, this is distinct from the `dates` field, which is concatenated from the start and end date fields. For ArchivistsToolkitClient, it's a duplication of the `dates` field, which already used the date expression field. (That should probably change in the future.)