### PR TITLE
ArchivesSpaceClient: handle no note content

### DIFF
--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -130,7 +130,7 @@ class ArchivesSpaceClient(object):
                     n['content'] = note['content'][0]
                 else:
                     n['content'] = note['subnotes'][0]['content']
-            except IndexError:
+            except (IndexError, KeyError):
                 n['content'] = ''
 
             notes.append(n)

--- a/tests/fixtures/test_contentless_notes.yaml
+++ b/tests/fixtures/test_contentless_notes.yaml
@@ -1,0 +1,139 @@
+interactions:
+- request:
+    body: !!binary |
+      cGFzc3dvcmQ9YWRtaW4mZXhwaXJpbmc9RmFsc2U=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['29']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: '{"session":"3436096c34006577491aae6c6dc485ce5a987afd90f79366c18ec63389ddb456","user":{"lock_version":808,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2016-01-07T20:55:29Z","user_mtime":"2016-01-07T20:55:29Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2206']
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jan 2016 20:55:29 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+      X-ArchivesSpace-Session: [3436096c34006577491aae6c6dc485ce5a987afd90f79366c18ec63389ddb456]
+    method: GET
+    uri: http://localhost:8089/repositories/2/search?page=1&page_size=30&q=primary_type%3Aresource
+  response:
+    body: {string: '{"first_page":1,"last_page":1,"this_page":1,"offset_first":1,"offset_last":3,"total_hits":3,"results":[{"id":"/repositories/2/resources/1","title":"Test
+        fonds","primary_type":"resource","types":["resource"],"json":"{\"lock_version\":11,\"title\":\"Test
+        fonds\",\"publish\":false,\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-06-11T17:08:42Z\",\"system_mtime\":\"2015-12-03T00:03:41Z\",\"user_mtime\":\"2015-12-03T00:03:41Z\",\"suppressed\":false,\"id_0\":\"F1\",\"language\":\"eng\",\"level\":\"fonds\",\"jsonmodel_type\":\"resource\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[{\"lock_version\":0,\"number\":\"1\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-03T00:03:42Z\",\"system_mtime\":\"2015-12-03T00:03:42Z\",\"user_mtime\":\"2015-12-03T00:03:42Z\",\"portion\":\"whole\",\"extent_type\":\"cassettes\",\"jsonmodel_type\":\"extent\"}],\"dates\":[{\"lock_version\":0,\"begin\":\"2015-01-01\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-03T00:03:42Z\",\"system_mtime\":\"2015-12-03T00:03:42Z\",\"user_mtime\":\"2015-12-03T00:03:42Z\",\"date_type\":\"single\",\"label\":\"creation\",\"jsonmodel_type\":\"date\"}],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"instances\":[],\"deaccessions\":[],\"related_accessions\":[{\"ref\":\"/repositories/2/accessions/1\"}],\"notes\":[{\"content\":[\"Singlepart
+        note\"],\"type\":\"physdesc\",\"jsonmodel_type\":\"note_singlepart\",\"persistent_id\":\"cdc013c483de98b8a1762302faf8fd32\",\"publish\":true}],\"uri\":\"/repositories/2/resources/1\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/resources/1/tree\"}}","suppressed":false,"publish":false,"system_generated":false,"repository":"/repositories/2","created_by":"admin","last_modified_by":"admin","user_mtime":"2015-12-03T00:03:41Z","system_mtime":"2015-12-03T00:03:41Z","create_time":"2015-06-11T17:08:42Z","level":"fonds","identifier":"F1","language":"eng","restrictions":"false","four_part_id":"F1","uri":"/repositories/2/resources/1","jsonmodel_type":"resource"},{"id":"/repositories/2/resources/2","title":"Some
+        other fonds","primary_type":"resource","types":["resource"],"json":"{\"lock_version\":4,\"title\":\"Some
+        other fonds\",\"publish\":false,\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-06-30T23:17:57Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"suppressed\":false,\"id_0\":\"F2\",\"level\":\"fonds\",\"jsonmodel_type\":\"resource\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[{\"lock_version\":0,\"number\":\"1\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"portion\":\"whole\",\"extent_type\":\"cassettes\",\"jsonmodel_type\":\"extent\"}],\"dates\":[{\"lock_version\":0,\"begin\":\"2015-06-29\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"date_type\":\"bulk\",\"label\":\"creation\",\"jsonmodel_type\":\"date\"}],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"instances\":[{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:21Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/3\",\"_resolved\":{\"lock_version\":4,\"digital_object_id\":\"f808032e-c6ec-4242-b7aa-5395988b9f7e\",\"title\":\"test\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T00:55:38Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T00:55:38Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"4e5eec95fcb62440f20a4f5b89c6d16b\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/3\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/3/tree\"}}}},{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:22Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:22Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/4\",\"_resolved\":{\"lock_version\":3,\"digital_object_id\":\"5517ddb1-36dd-4a02-a363-f1571982670f\",\"title\":\"test\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T00:55:53Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T00:55:53Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"bdfe911944a3d26a9fd43455aa968c52\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/4\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/4/tree\"}}}},{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:22Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:22Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/5\",\"_resolved\":{\"lock_version\":2,\"digital_object_id\":\"8ea81c4d-6df3-4775-a314-4bef4f44dd3c\",\"title\":\"Some
+        other fonds\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:04:57Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:04:57Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"68242ba5c0cbff4b674c6a2fa2335ad0\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/5\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/5/tree\"}}}},{\"lock_version\":0,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:22Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:22Z\",\"instance_type\":\"digital_object\",\"jsonmodel_type\":\"instance\",\"digital_object\":{\"ref\":\"/repositories/2/digital_objects/6\",\"_resolved\":{\"lock_version\":1,\"digital_object_id\":\"a1672927-9a56-41c4-b423-5d76e4a1c660\",\"title\":\"Some
+        other fonds\",\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2015-12-02T01:05:21Z\",\"system_mtime\":\"2015-12-02T01:05:22Z\",\"user_mtime\":\"2015-12-02T01:05:21Z\",\"suppressed\":false,\"digital_object_type\":\"text\",\"jsonmodel_type\":\"digital_object\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[],\"dates\":[],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"file_versions\":[],\"notes\":[{\"content\":[\"test\"],\"type\":\"originalsloc\",\"jsonmodel_type\":\"note_digital_object\",\"persistent_id\":\"3453d8096aabc607723b4359ab8fdd3c\",\"publish\":true}],\"linked_instances\":[{\"ref\":\"/repositories/2/resources/2\"}],\"uri\":\"/repositories/2/digital_objects/6\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/digital_objects/6/tree\"}}}}],\"deaccessions\":[],\"related_accessions\":[],\"notes\":[],\"uri\":\"/repositories/2/resources/2\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/resources/2/tree\"}}","suppressed":false,"publish":false,"system_generated":false,"repository":"/repositories/2","created_by":"admin","last_modified_by":"admin","user_mtime":"2015-12-02T01:05:21Z","system_mtime":"2015-12-02T01:05:21Z","create_time":"2015-06-30T23:17:57Z","level":"fonds","identifier":"F2","restrictions":"false","four_part_id":"F2","uri":"/repositories/2/resources/2","jsonmodel_type":"resource"},{"id":"/repositories/2/resources/4","title":"Resource
+        with a multipart contentless note","primary_type":"resource","types":["resource"],"json":"{\"lock_version\":1,\"title\":\"Resource
+        with a multipart contentless note\",\"publish\":false,\"restrictions\":false,\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2016-01-07T20:51:13Z\",\"system_mtime\":\"2016-01-07T20:53:13Z\",\"user_mtime\":\"2016-01-07T20:53:13Z\",\"suppressed\":false,\"id_0\":\"A\",\"id_1\":\"6\",\"language\":\"ain\",\"level\":\"collection\",\"jsonmodel_type\":\"resource\",\"external_ids\":[],\"subjects\":[],\"linked_events\":[],\"extents\":[{\"lock_version\":0,\"number\":\"5\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2016-01-07T20:53:14Z\",\"system_mtime\":\"2016-01-07T20:53:14Z\",\"user_mtime\":\"2016-01-07T20:53:14Z\",\"portion\":\"whole\",\"extent_type\":\"cassettes\",\"jsonmodel_type\":\"extent\"}],\"dates\":[{\"lock_version\":0,\"begin\":\"2016-01-06\",\"created_by\":\"admin\",\"last_modified_by\":\"admin\",\"create_time\":\"2016-01-07T20:53:14Z\",\"system_mtime\":\"2016-01-07T20:53:14Z\",\"user_mtime\":\"2016-01-07T20:53:14Z\",\"date_type\":\"single\",\"label\":\"creation\",\"jsonmodel_type\":\"date\"}],\"external_documents\":[],\"rights_statements\":[],\"linked_agents\":[],\"instances\":[],\"deaccessions\":[],\"related_accessions\":[],\"notes\":[{\"jsonmodel_type\":\"note_multipart\",\"persistent_id\":\"042fd712c1eae93e51fde8b4da1c455d\",\"type\":\"bioghist\",\"subnotes\":[{\"jsonmodel_type\":\"note_orderedlist\",\"title\":\"First\",\"items\":[\"Second\"],\"publish\":false}],\"publish\":false}],\"uri\":\"/repositories/2/resources/4\",\"repository\":{\"ref\":\"/repositories/2\"},\"tree\":{\"ref\":\"/repositories/2/resources/4/tree\"}}","suppressed":false,"publish":false,"system_generated":false,"repository":"/repositories/2","created_by":"admin","last_modified_by":"admin","user_mtime":"2016-01-07T20:53:13Z","system_mtime":"2016-01-07T20:53:13Z","create_time":"2016-01-07T20:51:13Z","level":"collection","identifier":"A-6","language":"ain","restrictions":"false","four_part_id":"A
+        6","uri":"/repositories/2/resources/4","jsonmodel_type":"resource"}],"facets":{"facet_queries":{},"facet_fields":{},"facet_dates":{},"facet_ranges":{}}}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['11630']
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jan 2016 20:55:29 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+      X-ArchivesSpace-Session: [3436096c34006577491aae6c6dc485ce5a987afd90f79366c18ec63389ddb456]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/1/tree?page=1
+  response:
+    body: {string: '{"title":"Test fonds","id":1,"node_type":"resource","publish":false,"suppressed":false,"children":[{"title":"Test
+        series, 1950 - 1972","id":1,"record_uri":"/repositories/2/archival_objects/1","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":true,"children":[{"title":"Test
+        edited subseries, November, 2014 to November, 2015","id":3,"record_uri":"/repositories/2/archival_objects/3","publish":false,"suppressed":false,"node_type":"archival_object","level":"subseries","has_children":true,"children":[{"title":"Test
+        file","id":4,"record_uri":"/repositories/2/archival_objects/4","publish":false,"suppressed":false,"node_type":"archival_object","level":"file","has_children":false,"children":[],"instance_types":[],"containers":[]}],"instance_types":[],"containers":[]},{"title":"New
+        new new child","id":10,"record_uri":"/repositories/2/archival_objects/10","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]}],"instance_types":[],"containers":[]},{"title":"Test
+        series 2","id":2,"record_uri":"/repositories/2/archival_objects/2","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Test
+        new child","id":13,"record_uri":"/repositories/2/archival_objects/13","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Test
+        new child 2","id":14,"record_uri":"/repositories/2/archival_objects/14","publish":false,"suppressed":false,"node_type":"archival_object","level":"item","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Test
+        new child 3","id":16,"record_uri":"/repositories/2/archival_objects/16","publish":false,"suppressed":false,"node_type":"archival_object","level":"class","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"New
+        child with note","id":17,"record_uri":"/repositories/2/archival_objects/17","publish":false,"suppressed":false,"node_type":"archival_object","level":"class","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"New
+        child final","id":18,"record_uri":"/repositories/2/archival_objects/18","publish":false,"suppressed":false,"node_type":"archival_object","level":null,"has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Child
+        with no note","id":19,"record_uri":"/repositories/2/archival_objects/19","publish":false,"suppressed":false,"node_type":"archival_object","level":"fonds","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Child
+        with no note","id":20,"record_uri":"/repositories/2/archival_objects/20","publish":false,"suppressed":false,"node_type":"archival_object","level":"fonds","has_children":false,"children":[],"instance_types":[],"containers":[]}],"record_uri":"/repositories/2/resources/1","level":"fonds","jsonmodel_type":"resource_tree","instance_types":[],"containers":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['3142']
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jan 2016 20:55:29 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+      X-ArchivesSpace-Session: [3436096c34006577491aae6c6dc485ce5a987afd90f79366c18ec63389ddb456]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/2/tree?page=1
+  response:
+    body: {string: '{"title":"Some other fonds","id":2,"node_type":"resource","publish":false,"suppressed":false,"children":[{"title":"New
+        resource child","id":12,"record_uri":"/repositories/2/archival_objects/12","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Child
+        with singlepart note","id":21,"record_uri":"/repositories/2/archival_objects/21","publish":false,"suppressed":false,"node_type":"archival_object","level":"series","has_children":false,"children":[],"instance_types":[],"containers":[]},{"title":"Child
+        with contentless note","id":22,"record_uri":"/repositories/2/archival_objects/22","publish":false,"suppressed":false,"node_type":"archival_object","level":"Other","has_children":false,"children":[],"instance_types":[],"containers":[]}],"record_uri":"/repositories/2/resources/2","level":"fonds","jsonmodel_type":"resource_tree","instance_types":[],"containers":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['980']
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jan 2016 20:55:30 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+      X-ArchivesSpace-Session: [3436096c34006577491aae6c6dc485ce5a987afd90f79366c18ec63389ddb456]
+    method: GET
+    uri: http://localhost:8089/repositories/2/resources/4/tree?page=1
+  response:
+    body: {string: '{"title":"Resource with a multipart contentless note","id":4,"node_type":"resource","publish":false,"suppressed":false,"children":[],"record_uri":"/repositories/2/resources/4","level":"collection","jsonmodel_type":"resource_tree","instance_types":[],"containers":[]}
+
+'}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['267']
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jan 2016 20:55:30 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_archivesspace_client.py
+++ b/tests/test_archivesspace_client.py
@@ -334,3 +334,11 @@ def test_empty_dates():
     assert record['date_expression'] == ''
     collections = client.find_collections()
     assert collections[0]['date_expression'] == ''
+
+
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_contentless_notes.yaml'))
+def test_contentless_notes():
+    client = ArchivesSpaceClient(**AUTH)
+    collections = client.find_collections()
+    assert collections[-1]['notes'][0]['type'] == 'bioghist'
+    assert collections[-1]['notes'][0]['content'] == ''


### PR DESCRIPTION
`n['content'] = note['subnotes'][0]['content']` raises if `content` doesn't exist, which can apparently happen.  Added catch of KeyError to handle this.