### PR TITLE
ArchivesSpace client: Handle notes with no content

### DIFF
--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -704,9 +704,14 @@ class ArchivesSpaceClient(object):
             else:
                 dnote = "note"
             if "subnotes" in pnote:
-                content = [subnote["content"] for subnote in pnote["subnotes"]]
+                content = []
+                for subnote in pnote['subnotes']:
+                    if 'content' in subnote:
+                        content.append(subnote['content'])
+                    else:
+                        LOGGER.info('No content field in %s, skipping adding to child digital object.', subnote)
             else:
-                content = pnote["content"]
+                content = pnote.get("content", '')
 
             new_object["notes"].append({
                 "jsonmodel_type": "note_digital_object",


### PR DESCRIPTION
When creating a digital object, handle notes from the parent that don't have a content attribute.  Log an error if notes are being skipped.

refs #9464

Copy of artefactual/archivematica#428 for agentarchives