### PR TITLE
ArchivesSpace: Allow editing multiple notes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Artefactual Systems",
     author_email="info@artefactual.com",
     license="AGPL 3",
-    version="0.2.2",
+    version="0.3.0",
     packages=["agentarchives", "agentarchives.archivesspace", "agentarchives.archivists_toolkit", "agentarchives.atom"],
     install_requires=["requests>=2,<3", "mysqlclient>=1.3,<2"],
     classifiers=[

--- a/tests/fixtures/test_edit_record_multiple_notes.yaml
+++ b/tests/fixtures/test_edit_record_multiple_notes.yaml
@@ -1,0 +1,107 @@
+interactions:
+- request:
+    body: expiring=False&password=admin
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.11.1]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: '{"session":"ad772ecb08b2d161a484c540690f5e93a61814cef5f0b362ac9ab1d833a139ec","user":{"lock_version":7815,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-09-22T18:46:11Z","system_mtime":"2017-02-09T22:14:36Z","user_mtime":"2017-02-09T22:14:36Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","system_config","administer_system","manage_users","become_user","view_all_records","create_repository","delete_repository","transfer_repository","index_system","manage_repository","update_accession_record","update_resource_record","update_digital_object_record","update_event_record","delete_event_record","suppress_archival_record","transfer_archival_record","delete_archival_record","view_suppressed","view_repository","update_classification_record","delete_classification_record","mediate_edits","import_records","cancel_importer_job","manage_subject_record","manage_agent_record","manage_vocabulary_record","merge_agents_and_subjects","merge_archival_record","manage_rde_templates"],"_archivesspace":["system_config","administer_system","manage_users","become_user","view_all_records","create_repository","delete_repository","transfer_repository","index_system","manage_repository","update_accession_record","update_resource_record","update_digital_object_record","update_event_record","delete_event_record","suppress_archival_record","transfer_archival_record","delete_archival_record","view_suppressed","view_repository","update_classification_record","delete_classification_record","mediate_edits","import_records","cancel_importer_job","manage_subject_record","manage_agent_record","manage_vocabulary_record","merge_agents_and_subjects","merge_archival_record","manage_rde_templates","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+        '}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['2253']
+      Content-Type: [application/json]
+      Date: ['Thu, 09 Feb 2017 22:14:35 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.11.1]
+      X-ArchivesSpace-Session: [ad772ecb08b2d161a484c540690f5e93a61814cef5f0b362ac9ab1d833a139ec]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/9253
+  response:
+    body: {string: '{"lock_version":0,"position":0,"ref_id":"deba72c5e3a1926de775574d7d2ca269","title":"holly-test","display_string":"holly-test","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2017-02-03T23:15:10Z","system_mtime":"2017-02-09T22:13:51Z","user_mtime":"2017-02-03T23:15:10Z","suppressed":false,"level":"file","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[],"uri":"/repositories/2/archival_objects/9253","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/4"},"parent":{"ref":"/repositories/2/archival_objects/8887"},"has_unpublished_ancestor":true}
+
+        '}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['772']
+      Content-Type: [application/json]
+      Date: ['Thu, 09 Feb 2017 22:14:36 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"has_unpublished_ancestor": true, "parent": {"ref": "/repositories/2/archival_objects/8887"},
+      "jsonmodel_type": "archival_object", "linked_events": [], "external_ids": [],
+      "created_by": "admin", "rights_statements": [], "level": "file", "user_mtime":
+      "2017-02-03T23:15:10Z", "last_modified_by": "admin", "suppressed": false, "repository":
+      {"ref": "/repositories/2"}, "display_string": "holly-test", "external_documents":
+      [], "dates": [], "extents": [], "system_mtime": "2017-02-09T22:13:51Z", "linked_agents":
+      [], "position": 0, "restrictions_apply": false, "resource": {"ref": "/repositories/2/resources/4"},
+      "uri": "/repositories/2/archival_objects/9253", "create_time": "2017-02-03T23:15:10Z",
+      "lock_version": 0, "notes": [{"subnotes": [{"content": "General note content",
+      "jsonmodel_type": "note_text", "publish": true}], "jsonmodel_type": "note_multipart",
+      "publish": true, "type": "odd"}, {"subnotes": [{"content": "Access restriction
+      note", "jsonmodel_type": "note_text", "publish": true}], "jsonmodel_type": "note_multipart",
+      "publish": true, "type": "accessrestrict"}], "title": "holly-test", "subjects":
+      [], "instances": [], "ref_id": "deba72c5e3a1926de775574d7d2ca269"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1181']
+      User-Agent: [python-requests/2.11.1]
+      X-ArchivesSpace-Session: [ad772ecb08b2d161a484c540690f5e93a61814cef5f0b362ac9ab1d833a139ec]
+    method: POST
+    uri: http://localhost:8089/repositories/2/archival_objects/9253
+  response:
+    body: {string: '{"status":"Updated","id":9253,"lock_version":1,"stale":true,"uri":"/repositories/2/archival_objects/9253","warnings":[]}
+
+        '}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      Date: ['Thu, 09 Feb 2017 22:14:36 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.11.1]
+      X-ArchivesSpace-Session: [ad772ecb08b2d161a484c540690f5e93a61814cef5f0b362ac9ab1d833a139ec]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/9253
+  response:
+    body: {string: '{"lock_version":1,"position":0,"publish":false,"ref_id":"deba72c5e3a1926de775574d7d2ca269","title":"holly-test","display_string":"holly-test","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2017-02-03T23:15:10Z","system_mtime":"2017-02-09T22:14:36Z","user_mtime":"2017-02-09T22:14:36Z","suppressed":false,"level":"file","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[{"subnotes":[{"content":"General
+        note content","jsonmodel_type":"note_text","publish":true}],"jsonmodel_type":"note_multipart","type":"odd","persistent_id":"5c593d5dc0281cbdeeebe07126375487","publish":true},{"subnotes":[{"content":"Access
+        restriction note","jsonmodel_type":"note_text","publish":true}],"jsonmodel_type":"note_multipart","type":"accessrestrict","persistent_id":"f2c649e8a7c1cba86647f26cad464804","publish":true}],"uri":"/repositories/2/archival_objects/9253","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/4"},"parent":{"ref":"/repositories/2/archival_objects/8887"},"has_unpublished_ancestor":true}
+
+        '}
+    headers:
+      Cache-Control: ['private, must-revalidate, max-age=0']
+      Content-Length: ['1215']
+      Content-Type: [application/json]
+      Date: ['Thu, 09 Feb 2017 22:14:36 GMT']
+      Server: [Jetty(8.1.5.v20120716)]
+      X-Content-Type-Options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_archivesspace_client.py
+++ b/tests/test_archivesspace_client.py
@@ -325,6 +325,30 @@ def test_edit_record_empty_note():
     updated = client.get_record('/repositories/2/archival_objects/3')
     assert not updated['notes']
 
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_edit_record_multiple_notes.yaml'))
+def test_edit_record_multiple_notes():
+    client = ArchivesSpaceClient(**AUTH)
+    new_record = {
+        'id': '/repositories/2/archival_objects/9253',
+        'notes': [
+            {
+                'type': 'odd',
+                'content': 'General note content'
+            },
+            {
+                'type': 'accessrestrict',
+                'content': 'Access restriction note',
+            }
+        ],
+    }
+    client.edit_record(new_record)
+    updated = client.get_record('/repositories/2/archival_objects/9253')
+    assert updated['notes'][0]['type'] == new_record['notes'][0]['type']
+    assert updated['notes'][0]['subnotes'][0]['content'] == new_record['notes'][0]['content']
+
+    assert updated['notes'][1]['type'] == new_record['notes'][1]['type']
+    assert updated['notes'][1]['subnotes'][0]['content'] == new_record['notes'][1]['content']
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_digital_object.yaml'))
 def test_add_digital_object():
     client = ArchivesSpaceClient(**AUTH)


### PR DESCRIPTION
Handle multiple odd or accessrestrict notes when updating a record. Only count as an update if new notes were actually generated.

refs #10864

This builds on #22  and relates to artefactual-labs/appraisal-tab#153