### PR TITLE
ArchivesSpace: Don't special case first note when editing a record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 *.egg-info
 *.pyc
 .cache
+/.env/
+/.tox/
+/.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+---
+
+sudo: false
+
+language: python
+
+before_script:
+  - pip install tox
+
+script: tox
+
+notifications:
+  email: false
+
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.6"
+      env: TOXENV=flake8
+  allow_failures:
+    - python: "3.6"
+      env: TOXENV=flake8

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,4 +1,5 @@
 -r base.txt
 
 pytest>=2,<3
+pytest-cov>=2,<3
 vcrpy>=1,<2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,py34,flake8
+
+[testenv]
+deps = -rrequirements/local.txt
+commands =  py.test --ignore=build -v --cov=agentarchives --cov-report=term-missing
+
+[testenv:flake8]
+basepython = python3
+skip_install = true
+deps = flake8
+commands = flake8 .
+
+[flake8]
+exclude = .env, .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs
+application-import-names = flake8


### PR DESCRIPTION
A list of notes may have more than one, and the first one being empty should not result in all subsequent notes being ignored.

refs redmine 10864, related to #38 

Input | Old behaviour | New behaviour
-----|-----|----
No notes submitted | Delete notes | Nothing
Empty list | Delete notes | Nothing 
Single empty note | Delete notes | Delete notes
Multiple notes, all are empty | Delete notes | Delete notes
Multiple notes, first is empty | Delete notes | Replace with only non-empty notes
Multiple notes with content | Replace with all notes | Replace with all notes

Note that note of these options merge with the existing notes - it always replaces the notes on the object with the newly submitted ones.