### PR TITLE
use display_string instead of title for digital object title

### DIFF
--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -671,7 +671,7 @@ class ArchivesSpaceClient(object):
 
         if not title:
             filename = os.path.basename(uri) if uri is not None else 'Untitled'
-            title = parent_record.get('title', filename)
+            title = parent_record.get('display_string', filename)
 
         new_object = {
             "title": title,


### PR DESCRIPTION
This fixes a bug in which digital objects were created with a title of "Untitled" if the parent archival object consisted of only dates. This uses the parent archival object's display_string, instead, which is a concatenation of its title (if it exists) and its first date entry.