### PR TITLE
Lyrasis-hosted ArchivesSpace fix

### DIFF
--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -49,12 +49,20 @@ class ArchivesSpaceClient(object):
     RESOURCE_COMPONENT = 'resource_component'
 
     def __init__(self, host, user, passwd, port=8089, repository=2, timeout=DEFAULT_TIMEOUT):
+        """
+        In order to make this library compatible with hosted ArchivesSpace
+        - 'host' shall be not only the host name but the url of the backend,
+          including protocol identifier, path and port number
+          For example 'https://myserver.org/api'
+                      'http://anotherserver.org:8089'
+        - 'port' will be ignored (not removed for now to avoid breaking changes)
+        """
         parsed = urlparse(host)
         if not parsed.scheme:
             host = 'http://' + host
 
         self.timeout = timeout
-        self.host = host + ':' + str(port)
+        self.host = host
         self.user = user
         self.passwd = passwd
         self.repository = '/repositories/{}'.format(repository)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Artefactual Systems",
     author_email="info@artefactual.com",
     license="AGPL 3",
-    version="0.3.0",
+    version="0.4.0",
     packages=["agentarchives", "agentarchives.archivesspace", "agentarchives.archivists_toolkit", "agentarchives.atom"],
     install_requires=["requests>=2,<3", "mysqlclient>=1.3,<2"],
     classifiers=[


### PR DESCRIPTION
In order to make this library compatible with Lyrasis-hosted ArchivesSpace, fix the ArchivesSpace class constructor parameters as follows:
- 'host' shall be not only the host name but the url of the backend, including protocol identifier, path and port number. For example 'https://myserver.org/api', 'http://anotherserver.org:8089'
- 'port' will be ignored (not removed for now to avoid breaking changes)

To match the changes in this fix, archivematica UI's ArchivesSpace DIP upload configuration page needs to be fixed as well. However the fixes in this PR work with current unfixed archivematica versions, just enter the url (including port number) in the "ArchivesSpace host" config box. 

Tested and seems to be working fine.