### PR TITLE
Revamp connection details support

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
-pytest>=2,<3
+pytest>=4,<5
 pytest-cov>=2,<3
+pytest-mock>=1,<2
 vcrpy>=1,<2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Artefactual Systems",
     author_email="info@artefactual.com",
     license="AGPL 3",
-    version="0.4.0",
+    version="0.5.0",
     packages=["agentarchives", "agentarchives.archivesspace", "agentarchives.archivists_toolkit", "agentarchives.atom"],
     install_requires=["requests>=2,<3", "mysqlclient>=1.3,<2"],
     classifiers=[


### PR DESCRIPTION
Better support for `host` values that are URLs. Added some tests to make
very explicit the pairs that we are accepting and refusing.

I've updated the dependencies described in `local.txt`. Tests are still
passing but it also fixes a dependency problem that was preventing the
environment from building - see build [#477140036](https://travis-ci.org/artefactual-labs/agentarchives/builds/477140036).

**BREAKING CHANGES**
- `ArchivematicaSpaceClient`: if `host` is a URL (e.g. it starts with `scheme://`) then `port` is ignored. For example, passing the argument `host="http://localhost"` will now be left as it is instead of resulting in `"http://localhost:8089"`.

It replaces https://github.com/artefactual-labs/agentarchives/pull/42/.
This is connected to https://github.com/archivematica/Issues/issues/409.