### PR TITLE
Make flake8 check mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,3 @@ matrix:
       env: TOXENV=py34
     - python: "3.6"
       env: TOXENV=flake8
-  allow_failures:
-    - python: "3.6"
-      env: TOXENV=flake8

--- a/agentarchives/archivesspace/__init__.py
+++ b/agentarchives/archivesspace/__init__.py
@@ -1,1 +1,1 @@
-from .client import *
+from .client import *  # noqa

--- a/agentarchives/archivesspace/client.py
+++ b/agentarchives/archivesspace/client.py
@@ -306,11 +306,9 @@ class ArchivesSpaceClient(object):
 
         self._post(record_id, data=json.dumps(record))
 
-
     def get_levels_of_description(self):
-        """
-        Returns an array of all levels of description defined in this ArchivesSpace instance.
-        """
+        """Returns an array of all levels of description defined in this
+        ArchivesSpace instance."""
         if not hasattr(self, 'levels_of_description'):
             # TODO: * fetch human-formatted strings
             #       * is hardcoding this ID okay?
@@ -752,7 +750,7 @@ class ArchivesSpaceClient(object):
                 "xlink_actuate_attribute": xlink_actuate,
             }]
 
-        note_digital_object_type = ["summary", "bioghist", "accessrestrict", "userestrict", "custodhist", "dimensions", "edition", "extent","altformavail", "originalsloc", "note", "acqinfo", "inscription", "langmaterial", "legalstatus", "physdesc", "prefercite", "processinfo", "relatedmaterial"]
+        note_digital_object_type = ["summary", "bioghist", "accessrestrict", "userestrict", "custodhist", "dimensions", "edition", "extent", "altformavail", "originalsloc", "note", "acqinfo", "inscription", "langmaterial", "legalstatus", "physdesc", "prefercite", "processinfo", "relatedmaterial", ]
 
         if inherit_notes:
             for pnote in parent_record["notes"]:

--- a/agentarchives/archivists_toolkit/__init__.py
+++ b/agentarchives/archivists_toolkit/__init__.py
@@ -1,1 +1,1 @@
-from .client import *
+from .client import *  # noqa

--- a/agentarchives/archivists_toolkit/client.py
+++ b/agentarchives/archivists_toolkit/client.py
@@ -221,7 +221,7 @@ class ArchivistsToolkitClient(object):
         # can use it to share state during recursion
 
         recurse_max_level = kwargs.get('recurse_max_level', False)
-        query             = kwargs.get('search_pattern', '')
+        query = kwargs.get('search_pattern', '')
 
         # intialize sort position if this is the beginning of recursion
         if level == 1:
@@ -237,26 +237,26 @@ class ArchivistsToolkitClient(object):
             cursor.execute("SELECT title, dateExpression, resourceIdentifier1, resourceLevel FROM Resources WHERE resourceid=%s", (resource_id))
 
             for row in cursor.fetchall():
-                resource_data['id']                 = resource_id
-                resource_data['type']               = 'resource'
-                resource_data['sortPosition']       = sort_data['position']
-                resource_data['title']              = row[0]
+                resource_data['id'] = resource_id
+                resource_data['type'] = 'resource'
+                resource_data['sortPosition'] = sort_data['position']
+                resource_data['title'] = row[0]
                 # TODO reformat dates from the separate date fields, like ArchivesSpaceClient?
-                resource_data['dates']              = row[1]
-                resource_data['date_expression']    = row[1]
-                resource_data['identifier']         = row[2]
+                resource_data['dates'] = row[1]
+                resource_data['date_expression'] = row[1]
+                resource_data['identifier'] = row[2]
                 resource_data['levelOfDescription'] = row[3]
         else:
             cursor.execute("SELECT title, dateExpression, persistentID, resourceLevel FROM ResourcesComponents WHERE resourceComponentId=%s", (resource_id))
 
             for row in cursor.fetchall():
-                resource_data['id']                 = resource_id
-                resource_data['type']               = 'resource_component'
-                resource_data['sortPosition']       = sort_data['position']
-                resource_data['title']              = row[0]
-                resource_data['dates']              = row[1]
-                resource_data['date_expression']    = row[1]
-                resource_data['identifier']         = row[2]
+                resource_data['id'] = resource_id
+                resource_data['type'] = 'resource_component'
+                resource_data['sortPosition'] = sort_data['position']
+                resource_data['title'] = row[0]
+                resource_data['dates'] = row[1]
+                resource_data['date_expression'] = row[1]
+                resource_data['identifier'] = row[2]
                 resource_data['levelOfDescription'] = row[3]
 
         # fetch children if we haven't reached the maximum recursion level

--- a/agentarchives/atom/__init__.py
+++ b/agentarchives/atom/__init__.py
@@ -1,1 +1,1 @@
-from .client import *
+from .client import *  # noqa

--- a/agentarchives/atom/client.py
+++ b/agentarchives/atom/client.py
@@ -144,8 +144,6 @@ class AtomClient(object):
 
     def _format_date_from_atom(self, date):
         # Map AtoM date specification to generic
-        updated_date = {}
-
         date_mapping = {
             'start_date': 'begin',
             'end_date': 'end',
@@ -200,7 +198,7 @@ class AtomClient(object):
             # within that note.
             # If the record already has at least one note, then replace the first note
             # within that record with this one.
-            if not 'notes' in record or record['notes'] == []:
+            if 'notes' not in record or record['notes'] == []:
                 record['notes'] = [new_note]
             else:
                 record['notes'][0] = new_note
@@ -222,9 +220,9 @@ class AtomClient(object):
         # Map agentarchives date specification to AtoM specification
         date_mapping = {
             'start_date': 'start_date',
-            #'begin': 'start_date',
+            # 'begin': 'start_date',
             'end_date': 'end_date',
-            #'end': 'end_date',
+            # 'end': 'end_date',
             'date_expression': 'date'
         }
 
@@ -539,8 +537,8 @@ class AtomClient(object):
         """
         resources_augmented = []
         for id in resource_ids:
-            #resource_data = self.get_resource_component_and_children(id, recurse_max_level=2)
-            #resources_augmented.append(resource_data)
+            # resource_data = self.get_resource_component_and_children(id, recurse_max_level=2)
+            # resources_augmented.append(resource_data)
             resources_augmented.append(
                 self.get_resource_component_and_children(id, recurse_max_level=2)
             )

--- a/tests/test_archivesspace_client.py
+++ b/tests/test_archivesspace_client.py
@@ -2,15 +2,12 @@
 import os
 
 import collections
-import sys
 
 import pytest
 import vcr
 
-here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, here)
-
 from agentarchives.archivesspace.client import ArchivesSpaceClient, ArchivesSpaceError, CommunicationError
+
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 AUTH = {
@@ -215,6 +212,7 @@ def test_find_collection_ids_search():
     ids = client.find_collection_ids(search_pattern='Some')
     assert ids == ['/repositories/2/resources/2']
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_count_collection_ids.yaml'))
 def test_count_collection_ids():
     client = ArchivesSpaceClient(**AUTH)
@@ -228,6 +226,7 @@ def test_count_collection_ids_search():
     ids = client.count_collections(search_pattern='Some')
     assert ids == 1
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_find_by_id_refid.yaml'))
 def test_find_by_id_refid():
     client = ArchivesSpaceClient(**AUTH)
@@ -240,6 +239,7 @@ def test_find_by_id_refid():
     assert item['title'] == 'Test AO'
     assert item['levelOfDescription'] == 'file'
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_augment_ids.yaml'))
 def test_augment_ids():
     client = ArchivesSpaceClient(**AUTH)
@@ -250,11 +250,13 @@ def test_augment_ids():
     assert data[1]['title'] == 'Some other fonds'
     assert data[1]['type'] == 'resource'
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_resource_type.yaml'))
 def test_get_resource_type():
     client = ArchivesSpaceClient(**AUTH)
     assert client.resource_type('/repositories/2/resources/2') == 'resource'
     assert client.resource_type('/repositories/2/archival_objects/3') == 'resource_component'
+
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_resource_type.yaml'))
 def test_get_resource_type_raises_on_invalid_input():
@@ -262,12 +264,14 @@ def test_get_resource_type_raises_on_invalid_input():
     with pytest.raises(ArchivesSpaceError):
         client.resource_type('invalid')
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_identifier_exact_match.yaml'))
 def test_identifier_search_exact_match():
     client = ArchivesSpaceClient(**AUTH)
     assert client.find_collection_ids(identifier='F1') == ['/repositories/2/resources/1']
     assert client.count_collections(identifier='F1') == 1
     assert len(client.find_collections(identifier='F1')) == 1
+
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_identifier_wildcard.yaml'))
 def test_identifier_search_wildcard():
@@ -281,17 +285,20 @@ def test_identifier_search_wildcard():
     assert client.count_collections(identifier='F*') == 2
     assert len(client.find_collections(identifier='F*')) == 2
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_child_resource.yaml'))
 def test_add_child_resource():
     client = ArchivesSpaceClient(**AUTH)
     uri = client.add_child('/repositories/2/resources/2', title='Test child', level='item')
     assert uri == '/repositories/2/archival_objects/3'
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_child_resource_component.yaml'))
 def test_add_child_resource_component():
     client = ArchivesSpaceClient(**AUTH)
     uri = client.add_child('/repositories/2/archival_objects/1', title='Test child', level='item')
     assert uri == '/repositories/2/archival_objects/5'
+
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_adding_child_with_note.yaml'))
 def test_adding_child_with_note():
@@ -302,6 +309,7 @@ def test_adding_child_with_note():
                            notes=[{'type': 'odd', 'content': 'This is a test note'}])
     assert uri == '/repositories/2/archival_objects/24'
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_posting_contentless_note.yaml'))
 def test_posting_contentless_note():
     client = ArchivesSpaceClient(**AUTH)
@@ -310,6 +318,7 @@ def test_posting_contentless_note():
                            level='recordgrp',
                            notes=[{'type': 'odd', 'content': ''}])
     assert client.get_record(uri)['notes'] == []
+
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_posting_multiple_notes.yaml'))
 def test_posting_multiple_notes():
@@ -324,6 +333,7 @@ def test_posting_multiple_notes():
     assert record['notes'][1]['type'] == 'accessrestrict'
     assert record['notes'][1]['subnotes'][0]['content'] == 'Access'
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_record_resource.yaml'))
 def test_delete_record_resource():
     client = ArchivesSpaceClient(**AUTH)
@@ -334,6 +344,7 @@ def test_delete_record_resource():
     with pytest.raises(CommunicationError):
         client.get_record(record_id)
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_record_archival_object.yaml'))
 def test_delete_record_archival_object():
     client = ArchivesSpaceClient(**AUTH)
@@ -343,6 +354,7 @@ def test_delete_record_archival_object():
     assert r['status'] == 'Deleted'
     with pytest.raises(CommunicationError):
         client.get_record(record_id)
+
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_edit_archival_object.yaml'))
 def test_edit_archival_object():
@@ -392,6 +404,7 @@ def test_edit_record_empty_note():
     updated = client.get_record('/repositories/2/archival_objects/3')
     assert not updated['notes']
 
+
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_edit_record_multiple_notes.yaml'))
 def test_edit_record_multiple_notes():
     client = ArchivesSpaceClient(**AUTH)
@@ -415,6 +428,7 @@ def test_edit_record_multiple_notes():
 
     assert updated['notes'][1]['type'] == new_record['notes'][1]['type']
     assert updated['notes'][1]['subnotes'][0]['content'] == new_record['notes'][1]['content']
+
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_add_digital_object.yaml'))
 def test_add_digital_object():

--- a/tests/test_atom_client.py
+++ b/tests/test_atom_client.py
@@ -2,13 +2,9 @@
 import os
 
 import pytest
-import sys
 import vcr
 
-here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, here)
-
-from agentarchives.atom.client  import AtomClient, AtomError, CommunicationError
+from agentarchives.atom.client import AtomClient, CommunicationError
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 AUTH = {
@@ -21,7 +17,7 @@ AUTH = {
 def test_levels_of_description():
     client = AtomClient(**AUTH)
     levels = client.get_levels_of_description()
-    assert levels == [u'Collection', u'File', u'Fonds', u'Item', u'Part', u'Series', u'Subfonds', u'Subseries'] 
+    assert levels == [u'Collection', u'File', u'Fonds', u'Item', u'Part', u'Series', u'Subfonds', u'Subseries']
 
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures/atom', 'test_listing_collections.yaml'))
@@ -125,7 +121,7 @@ def test_find_resource_children_recursion_level():
     assert data['has_children'] is True
 
 
-@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures/atom', 'test_find_resource_children_recursion_level_two.yaml'))
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures/atom', 'test_find_resource_children_recursion_level_two.yaml'))  # noqa
 def test_find_resource_children_recursion_level():
     client = AtomClient(**AUTH)
     data = client.get_resource_component_and_children('test-fonds',
@@ -208,9 +204,9 @@ def test_add_child_resource_component():
 def test_adding_child_with_note():
     client = AtomClient(**AUTH)
     slug = client.add_child('test-fonds',
-                           title='Another subfonds',
-                           level='subfonds',
-                           notes=[{'type': 'general', 'content': 'This is a test note'}])
+                            title='Another subfonds',
+                            level='subfonds',
+                            notes=[{'type': 'general', 'content': 'This is a test note'}])
     assert slug == 'another-subfonds'
 
 
@@ -218,9 +214,9 @@ def test_adding_child_with_note():
 def test_posting_contentless_note():
     client = AtomClient(**AUTH)
     slug = client.add_child('test-fonds',
-                           title='Yet another subfonds',
-                           level='subfonds',
-                           notes=[{'type': 'general', 'content': ''}])
+                            title='Yet another subfonds',
+                            level='subfonds',
+                            notes=[{'type': 'general', 'content': ''}])
     assert client.get_record(slug)['notes'] == []
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,4 @@ commands = flake8 .
 [flake8]
 exclude = .env, .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs
 application-import-names = flake8
+ignore = E501


### PR DESCRIPTION
This pull request makes the flake8 check mandatory. Additionally, it converts `tests` into a package (added empty `__init__.py` file) so we don't have to update `sys.path` dynamically to import `agentarchives` from our test files.

This is connected to https://github.com/artefactual-labs/agentarchives/issues/50.