### PR TITLE
Pass extra parameters for AtoM DO creation

### DIFF
--- a/agentarchives/atom/client.py
+++ b/agentarchives/atom/client.py
@@ -635,6 +635,8 @@ class AtomClient(object):
         aip_uuid=None,
         inherit_dates=False,
         usage=None,
+        aip_name=None,
+        relative_path_within_aip=None,
     ):
         """ Creates a new digital object. """
 
@@ -659,6 +661,10 @@ class AtomClient(object):
             new_object["file_uuid"] = file_uuid
         if aip_uuid is not None:
             new_object["aip_uuid"] = aip_uuid
+        if aip_name is not None:
+            new_object["aip_name"] = aip_name
+        if relative_path_within_aip is not None:
+            new_object["relative_path_within_aip"] = relative_path_within_aip
 
         if format_name is not None:
             new_object["format_name"] = format_name

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Artefactual Systems",
     author_email="info@artefactual.com",
     license="AGPL 3",
-    version="0.6.0",
+    version="0.7.0",
     packages=[
         "agentarchives",
         "agentarchives.archivesspace",


### PR DESCRIPTION
This sends the AIP name and relative path of the file that are needed
by AtoM's extract file action for metadata-only DIP uploads from
Archivematica.

It also bumps the package version for a new release.

Connected to https://github.com/archivematica/Issues/issues/1334