### PR TITLE
Fix ArchivesSpace URL parsing in Python 3.9+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         uses: "codecov/codecov-action@v3"
         with:
           files: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
   lint:
     name: "Lint"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,19 @@ on:
       - "master"
 jobs:
   tox:
-    name: "Test ${{ matrix.toxenv }}"
+    name: "Test Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-20.04"
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - python-version: "3.6"
-            toxenv: "py36"
-          - python-version: "3.7"
-            toxenv: "py37"
-          - python-version: "3.8"
-            toxenv: "py38"
+        python-version: [
+          "3.6",
+          "3.7",
+          "3.8",
+          "3.9",
+          "3.10",
+          "3.11",
+        ]
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v3"
@@ -39,10 +41,8 @@ jobs:
       - name: "Install tox"
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install tox tox-gh-actions
       - name: "Run tox"
-        env:
-          TOXENV: ${{ matrix.toxenv }}
         run: |
           tox -- --cov-config .coveragerc --cov-report xml:coverage.xml
       - name: "Upload coverage report"
@@ -52,8 +52,6 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
-          name: ${{ matrix.toxenv }}
-          flags: ${{ matrix.toxenv }}
   lint:
     name: "Lint"
     runs-on: "ubuntu-22.04"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.0
+  rev: v3.10.1
   hooks:
   - id: pyupgrade
     args: [--py3-plus, --py36-plus]
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.6.0
+  rev: v3.10.0
   hooks:
   - id: reorder-python-imports
     args: [--py3-plus, --py36-plus]
-- repo: https://github.com/ambv/black
-  rev: 22.8.0
+- repo: https://github.com/psf/black
+  rev: "23.7.0"
   hooks:
   - id: black
     args: [--safe, --quiet]
     language_version: python3
 - repo: https://github.com/pycqa/flake8
-  rev: 5.0.4
+  rev: "6.1.0"
   hooks:
   - id: flake8
     language_version: python3

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ package-source:
 	python setup.py sdist
 
 package-wheel: package-deps
-	python setup.py bdist_wheel --universal
+	python setup.py bdist_wheel
 
 package-upload: package-deps package-source package-wheel
 	twine upload dist/* --repository-url https://upload.pypi.org/legacy/

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,2 @@
-requests>=2,<3
-mysqlclient>=1.4,<2
-urllib3<2
+requests
+mysqlclient

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
+import codecs
+from os import path
+
 from setuptools import setup
+
+
+here = path.abspath(path.dirname(__file__))
+
+with codecs.open(path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
 
 setup(
     name="agentarchives",
     description="Clients to retrieve, add, and modify records from archival management systems",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/artefactual-labs/agentarchives",
     author="Artefactual Systems",
     author_email="info@artefactual.com",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "agentarchives.archivists_toolkit",
         "agentarchives.atom",
     ],
-    install_requires=["requests>=2,<3", "mysqlclient>=1.4,<2"],
+    install_requires=["requests", "mysqlclient"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -23,5 +23,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tests/test_archivesspace_client.py
+++ b/tests/test_archivesspace_client.py
@@ -18,6 +18,7 @@ AUTH = {"host": "http://localhost:8089", "user": "admin", "passwd": "admin"}
     [
         # These are pairs that we don't like and we raise.
         ({"host": "", "port": ""}, True, None),
+        ({"host": None, "port": None}, True, None),
         ({"host": "", "port": "string"}, True, None),
         ({"host": "string", "port": "string"}, True, None),
         # When `host` is not a URL.
@@ -26,6 +27,10 @@ AUTH = {"host": "http://localhost:8089", "user": "admin", "passwd": "admin"}
         ({"host": "localhost", "port": 12345}, False, "http://localhost:12345"),
         ({"host": "localhost", "port": "12345"}, False, "http://localhost:12345"),
         ({"host": "localhost", "port": None}, False, "http://localhost"),
+        ({"host": "localhost", "port": ""}, False, "http://localhost"),
+        ({"host": "foobar.tld", "port": ""}, False, "http://foobar.tld"),
+        ({"host": "foobar.tld", "port": None}, False, "http://foobar.tld"),
+        ({"host": "foobar.tld", "port": "12345"}, False, "http://foobar.tld:12345"),
         # When `host` is a URL!
         ({"host": "http://apiserver"}, False, "http://apiserver"),
         (
@@ -149,7 +154,7 @@ def test_find_resource_children():
     client = ArchivesSpaceClient(**AUTH)
     data = client.get_resource_component_and_children("/repositories/2/resources/1")
 
-    assert type(data) == dict
+    assert isinstance(data, dict)
     assert len(data["children"]) == 2
     assert data["has_children"] is True
     assert data["title"] == "Test fonds"

--- a/tests/test_atom_client.py
+++ b/tests/test_atom_client.py
@@ -141,7 +141,7 @@ def test_find_resource_children():
     client = AtomClient(**AUTH)
     data = client.get_resource_component_and_children("test-fonds")
 
-    assert type(data) == dict
+    assert isinstance(data, dict)
     assert len(data["children"]) == 1
     assert data["has_children"] is True
     assert data["title"] == "Test fonds"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,14 @@
 [tox]
-envlist = py{36,37,38}, flake8, linting
+envlist = py{36,37,38,39,310,311}, linting
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 deps = -rrequirements/local.txt


### PR DESCRIPTION
This handles a [backward incompatible change](https://bugs.python.org/issue27657) done in Python 3.9 when parsing URLs from ArchivesSpace. If the URL doesn't contain a scheme this uses the existing logic in the `ArchivesSpaceClient` class to calculate it correctly.

The package and CI configurations have also been updated to support new Python versions.

Connected to https://github.com/archivematica/Issues/issues/1330